### PR TITLE
Updated TCPDF to round values to 5dp

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6382,7 +6382,7 @@ class TCPDF {
 		$pc = 0; // previous character
 		// for each character
 		while ($i < $nb) {
-			if (($maxh > 0) AND ($this->y > $maxy) ) {
+			if (($maxh > 0) AND (number_format($this->y, 5) > number_format($maxy, 5)) ) {
 				break;
 			}
 			//Get the current character

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6382,7 +6382,7 @@ class TCPDF {
 		$pc = 0; // previous character
 		// for each character
 		while ($i < $nb) {
-			if (($maxh > 0) AND (number_format($this->y, 5) > number_format($maxy, 5)) ) {
+			if (($maxh > 0) AND (round($this->y, 5) > round($maxy, 5)) ) {
 				break;
 			}
 			//Get the current character


### PR DESCRIPTION
Rounded to 5dp as the floating point numbers were not matching even though they should have been. Which was meaning that some data which should have been printed, was not printed.